### PR TITLE
feat(questions): add open questions tracking per agenda

### DIFF
--- a/features/sync-vision/components/OpenQuestionsPanel.tsx
+++ b/features/sync-vision/components/OpenQuestionsPanel.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useState } from "react";
+import {
+  HelpCircle,
+  CheckCircle2,
+  Circle,
+  ChevronDown,
+  ChevronUp,
+  User,
+  Lightbulb,
+  AlertCircle,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { OpenQuestion } from "@/types/frames";
+
+interface OpenQuestionsPanelProps {
+  questions: OpenQuestion[];
+  onToggleResolved?: (questionId: string) => void;
+  className?: string;
+}
+
+interface QuestionCardProps {
+  question: OpenQuestion;
+  onToggleResolved?: (questionId: string) => void;
+}
+
+function QuestionCard({ question, onToggleResolved }: QuestionCardProps) {
+  const [isExpanded, setIsExpanded] = useState(true);
+
+  return (
+    <div
+      className={cn(
+        "border rounded-lg overflow-hidden transition-all",
+        question.resolved
+          ? "bg-green-50 border-green-200 opacity-60"
+          : "bg-white border-amber-200"
+      )}
+    >
+      {/* Header */}
+      <div
+        className="flex items-start gap-2 p-3 cursor-pointer hover:bg-gray-50/50"
+        onClick={() => setIsExpanded(!isExpanded)}
+      >
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onToggleResolved?.(question.id);
+          }}
+          className="mt-0.5 flex-shrink-0"
+        >
+          {question.resolved ? (
+            <CheckCircle2 className="h-5 w-5 text-green-600" />
+          ) : (
+            <Circle className="h-5 w-5 text-amber-500" />
+          )}
+        </button>
+
+        <div className="flex-1 min-w-0">
+          <p
+            className={cn(
+              "font-medium text-sm",
+              question.resolved && "line-through text-gray-500"
+            )}
+          >
+            {question.question}
+          </p>
+          {question.speaker && (
+            <div className="flex items-center gap-1 text-xs text-gray-500 mt-1">
+              <User className="h-3 w-3" />
+              {question.speaker}
+            </div>
+          )}
+        </div>
+
+        {isExpanded ? (
+          <ChevronUp className="h-4 w-4 text-gray-400 flex-shrink-0" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-gray-400 flex-shrink-0" />
+        )}
+      </div>
+
+      {/* Expanded content */}
+      {isExpanded && !question.resolved && (
+        <div className="px-3 pb-3 space-y-2 border-t border-gray-100 pt-2">
+          {/* Current Understanding */}
+          {question.currentUnderstanding && (
+            <div className="flex gap-2">
+              <Lightbulb className="h-4 w-4 text-blue-500 flex-shrink-0 mt-0.5" />
+              <div>
+                <p className="text-xs font-medium text-blue-700">わかっていること</p>
+                <p className="text-xs text-gray-600">{question.currentUnderstanding}</p>
+              </div>
+            </div>
+          )}
+
+          {/* Information Needed */}
+          {question.informationNeeded && (
+            <div className="flex gap-2">
+              <AlertCircle className="h-4 w-4 text-amber-500 flex-shrink-0 mt-0.5" />
+              <div>
+                <p className="text-xs font-medium text-amber-700">回答が必要</p>
+                <p className="text-xs text-gray-600">{question.informationNeeded}</p>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function OpenQuestionsPanel({
+  questions,
+  onToggleResolved,
+  className,
+}: OpenQuestionsPanelProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  const unresolvedCount = questions.filter((q) => !q.resolved).length;
+  const resolvedCount = questions.filter((q) => q.resolved).length;
+
+  if (questions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className={cn("border-t bg-amber-50/50", className)}>
+      {/* Header */}
+      <button
+        onClick={() => setIsCollapsed(!isCollapsed)}
+        className="w-full flex items-center justify-between p-3 hover:bg-amber-100/50 transition-colors"
+      >
+        <div className="flex items-center gap-2">
+          <HelpCircle className="h-4 w-4 text-amber-600" />
+          <span className="font-medium text-sm text-amber-800">
+            残論点
+          </span>
+          {unresolvedCount > 0 && (
+            <span className="bg-amber-500 text-white text-xs px-1.5 py-0.5 rounded-full">
+              {unresolvedCount}
+            </span>
+          )}
+          {resolvedCount > 0 && (
+            <span className="text-xs text-gray-500">
+              ({resolvedCount} 解決済み)
+            </span>
+          )}
+        </div>
+        {isCollapsed ? (
+          <ChevronDown className="h-4 w-4 text-gray-400" />
+        ) : (
+          <ChevronUp className="h-4 w-4 text-gray-400" />
+        )}
+      </button>
+
+      {/* Questions list */}
+      {!isCollapsed && (
+        <div className="p-3 pt-0 space-y-2 max-h-[300px] overflow-y-auto">
+          {/* Unresolved questions first */}
+          {questions
+            .filter((q) => !q.resolved)
+            .map((question) => (
+              <QuestionCard
+                key={question.id}
+                question={question}
+                onToggleResolved={onToggleResolved}
+              />
+            ))}
+
+          {/* Resolved questions */}
+          {questions
+            .filter((q) => q.resolved)
+            .map((question) => (
+              <QuestionCard
+                key={question.id}
+                question={question}
+                onToggleResolved={onToggleResolved}
+              />
+            ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/features/sync-vision/components/RealtimeSession.tsx
+++ b/features/sync-vision/components/RealtimeSession.tsx
@@ -14,7 +14,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import type { Frame, FrameType, TranscriptSegment } from "@/types/frames";
+import type { Frame, FrameType, TranscriptSegment, OpenQuestion } from "@/types/frames";
 import {
   createDeepgramWebSocket,
   sendAudioToDeepgram,
@@ -26,6 +26,7 @@ import {
   createEmptyFrame,
 } from "@/lib/ai/gemini-realtime";
 import { LogicTree, Whiteboard, MatrixFrame, TimelineFrame } from "./frames";
+import { OpenQuestionsPanel } from "./OpenQuestionsPanel";
 
 type RecordingStatus = "idle" | "recording" | "paused";
 
@@ -57,6 +58,7 @@ export function RealtimeSession({
   const [selectedFrameType, setSelectedFrameType] = useState<FrameType | null>(null);
   const [summary, setSummary] = useState("");
   const [frameReason, setFrameReason] = useState("");
+  const [openQuestions, setOpenQuestions] = useState<OpenQuestion[]>([]);
 
   // Refs
   const socketRef = useRef<WebSocket | null>(null);
@@ -107,6 +109,7 @@ export function RealtimeSession({
 
       setSummary(result.summary);
       setFrameReason(result.frameReason);
+      setOpenQuestions(result.openQuestions || []);
       lastAnalyzedTextRef.current = transcript;
     } catch (err) {
       console.error("Analysis error:", err);
@@ -236,7 +239,16 @@ export function RealtimeSession({
     setSelectedFrameType(null);
     setSummary("");
     setFrameReason("");
+    setOpenQuestions([]);
     lastAnalyzedTextRef.current = "";
+  };
+
+  const handleToggleQuestionResolved = (questionId: string) => {
+    setOpenQuestions((prev) =>
+      prev.map((q) =>
+        q.id === questionId ? { ...q, resolved: !q.resolved } : q
+      )
+    );
   };
 
   const displayFrameType = selectedFrameType || currentFrame.type;
@@ -366,6 +378,12 @@ export function RealtimeSession({
               <strong>AI提案:</strong> {frameReason}
             </div>
           )}
+
+          {/* Open Questions Panel */}
+          <OpenQuestionsPanel
+            questions={openQuestions}
+            onToggleResolved={handleToggleQuestionResolved}
+          />
         </div>
       </div>
     </div>

--- a/lib/ai/gemini-realtime.ts
+++ b/lib/ai/gemini-realtime.ts
@@ -139,6 +139,27 @@ const REALTIME_ANALYSIS_PROMPT = `あなたは会議ファシリテーション�
 - orange: 重要な指摘
 - purple: 未決定事項、要検討
 
+## 残論点（Open Questions）の抽出
+
+全てのフレームタイプで、以下の形式で残論点を出力してください:
+
+"openQuestions": [
+  {
+    "id": "q1",
+    "question": "明らかにすべき論点（質問形式で）",
+    "currentUnderstanding": "現時点でわかっていること",
+    "informationNeeded": "回答が欲しい具体的な内容",
+    "resolved": false,
+    "speaker": "この論点を提起した人（わかれば）"
+  }
+]
+
+### 残論点の抽出ルール
+- 議論の中で「〜はどうする？」「〜について検討が必要」「まだ決まっていない」などの発言を検出
+- 明確な結論が出ていない項目を抽出
+- 具体的なアクションや決定事項につながる質問を優先
+- 残論点がない場合は空配列 [] を返す
+
 ## 注意事項
 - 会話内容がまだ少ない場合は whiteboard で付箋として整理
 - 会話が進むにつれて適切なフレームに変更を提案
@@ -146,6 +167,7 @@ const REALTIME_ANALYSIS_PROMPT = `あなたは会議ファシリテーション�
 - timelineのカテゴリは議論内容に応じて適切な数と内容を設定すること
 - 発言者名が分かる場合は speaker フィールドに記録
 - idは一意になるよう連番で付与
+- **必ずopenQuestionsフィールドを出力に含めること**
 
 会話内容:
 `;
@@ -203,6 +225,10 @@ export async function analyzeConversationRealtime(
   try {
     const result = JSON.parse(text) as RealtimeAnalysisResult;
     result.lastProcessedText = transcript;
+    // Ensure openQuestions is always an array
+    if (!result.openQuestions) {
+      result.openQuestions = [];
+    }
     return result;
   } catch {
     throw new Error(`Failed to parse Gemini response: ${text}`);

--- a/types/frames.ts
+++ b/types/frames.ts
@@ -104,6 +104,18 @@ export interface TimelineFrame {
 export type Frame = MatrixFrame | LogicTreeFrame | WhiteboardFrame | TimelineFrame;
 
 // ============================================
+// Open Questions (残論点)
+// ============================================
+export interface OpenQuestion {
+  id: string;
+  question: string;
+  currentUnderstanding: string;
+  informationNeeded: string;
+  resolved: boolean;
+  speaker?: string;
+}
+
+// ============================================
 // Analysis result from Gemini
 // ============================================
 export interface RealtimeAnalysisResult {
@@ -111,6 +123,7 @@ export interface RealtimeAnalysisResult {
   frameReason: string;
   frame: Frame;
   summary: string;
+  openQuestions: OpenQuestion[];
   lastProcessedText: string;
 }
 


### PR DESCRIPTION
## Summary
Add automatic tracking of open questions (残論点) extracted from conversation.

## Features

### Open Questions Panel
Displays for each unresolved discussion point:
| Field | Description |
|-------|-------------|
| **Question** | The point that needs clarification |
| **Current Understanding** | What has been established so far |
| **Information Needed** | Specific answers required |

### Capabilities
- AI automatically extracts open questions during analysis
- Visual indicator for unresolved vs resolved questions
- Click to toggle question resolution status
- Collapsible panel in sidebar
- Unresolved count badge

## Files Changed
- `types/frames.ts` - Add OpenQuestion type
- `lib/ai/gemini-realtime.ts` - Update prompt for question extraction
- `features/sync-vision/components/OpenQuestionsPanel.tsx` - New component
- `features/sync-vision/components/RealtimeSession.tsx` - Integrate panel

## Test Plan
- [ ] Start recording and discuss a topic with unresolved points
- [ ] Verify questions appear in the panel
- [ ] Click question checkbox to mark as resolved
- [ ] Verify resolved questions show strikethrough
- [ ] Clear session and verify questions are cleared

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)