### PR TITLE
feat(extension): add Chrome extension for tab audio capture

### DIFF
--- a/extensions/chrome/README.md
+++ b/extensions/chrome/README.md
@@ -1,0 +1,119 @@
+# SyncVision Audio Capture Chrome Extension
+
+Chrome extension to capture audio from meeting tabs for real-time transcription in SyncVision.
+
+## Features
+
+- Capture audio from Google Meet, Zoom Web, and Microsoft Teams
+- Stream audio to SyncVision web app for transcription
+- Visual recording indicator on meeting pages
+
+## Installation
+
+### Development Mode
+
+1. Open Chrome and navigate to `chrome://extensions/`
+2. Enable "Developer mode" (toggle in top-right corner)
+3. Click "Load unpacked"
+4. Select this `extensions/chrome` directory
+5. The extension should appear in your toolbar
+
+### Generate Icons
+
+The extension requires PNG icons. Generate them from the SVG:
+
+```bash
+# Using ImageMagick (install via Homebrew: brew install imagemagick)
+cd extensions/chrome/icons
+convert -background none icon.svg -resize 16x16 icon16.png
+convert -background none icon.svg -resize 32x32 icon32.png
+convert -background none icon.svg -resize 48x48 icon48.png
+convert -background none icon.svg -resize 128x128 icon128.png
+```
+
+Or use any online SVG to PNG converter.
+
+## Usage
+
+1. Start the SyncVision web app (`npm run dev`)
+2. Open a supported meeting site (Google Meet, Zoom, or Teams)
+3. Click the SyncVision extension icon
+4. Enter your server URL (default: `http://localhost:3000`)
+5. Click "Start Capture"
+6. The meeting audio will be transcribed in real-time
+
+## Supported Sites
+
+| Site | URL Pattern |
+|------|-------------|
+| Google Meet | `meet.google.com/*` |
+| Zoom Web | `*.zoom.us/*` |
+| Microsoft Teams | `teams.microsoft.com/*` |
+
+## Permissions
+
+- `tabCapture` - Required to capture tab audio
+- `activeTab` - Access current tab information
+- `storage` - Save user settings
+
+## Technical Details
+
+### Architecture
+
+```
+Extension                          Web App
+   │                                  │
+   ├── tabCapture API ───────────────>│
+   │   (capture audio)                │
+   │                                  │
+   ├── WebSocket ────────────────────>│ /api/audio
+   │   (stream PCM audio)             │
+   │                                  │
+   │                                  ├──> Deepgram
+   │                                  │    (transcription)
+   │                                  │
+   │                                  ├──> Gemini
+   │                                  │    (analysis)
+```
+
+### Audio Format
+
+- Sample Rate: 16000 Hz
+- Channels: 1 (mono)
+- Format: 16-bit PCM (Int16Array)
+
+## Development
+
+### Files
+
+| File | Description |
+|------|-------------|
+| `manifest.json` | Extension configuration |
+| `popup/popup.html` | Extension popup UI |
+| `popup/popup.js` | Popup logic |
+| `background/service-worker.js` | Audio capture and streaming |
+| `content/content.js` | Meeting site integration |
+
+### Debugging
+
+1. Open `chrome://extensions/`
+2. Find SyncVision extension
+3. Click "service worker" to open DevTools for background script
+4. Click "Inspect views: popup" to debug popup
+
+## Troubleshooting
+
+### "Failed to capture tab audio"
+- Make sure you're on a supported meeting site
+- Check that the tab has audio playing
+- Try refreshing the page
+
+### WebSocket connection failed
+- Verify the web app is running
+- Check the server URL is correct
+- Look for CORS errors in console
+
+### No audio data received
+- Check that the meeting audio is not muted
+- Verify the microphone/speaker is working
+- Try adjusting the volume

--- a/extensions/chrome/background/service-worker.js
+++ b/extensions/chrome/background/service-worker.js
@@ -1,0 +1,241 @@
+// Background service worker for SyncVision Audio Capture
+
+// State
+let state = {
+  isCapturing: false,
+  tabId: null,
+  tabUrl: null,
+  serverUrl: null,
+  mediaStream: null,
+  websocket: null,
+  audioContext: null,
+  processor: null,
+};
+
+// Message handlers
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  switch (message.type) {
+    case "GET_STATE":
+      sendResponse({
+        isCapturing: state.isCapturing,
+        tabId: state.tabId,
+        tabUrl: state.tabUrl,
+      });
+      return true;
+
+    case "START_CAPTURE":
+      startCapture(message.tabId, message.serverUrl)
+        .then(() => sendResponse({ success: true }))
+        .catch((error) => sendResponse({ error: error.message }));
+      return true;
+
+    case "STOP_CAPTURE":
+      stopCapture()
+        .then(() => sendResponse({ success: true }))
+        .catch((error) => sendResponse({ error: error.message }));
+      return true;
+
+    default:
+      sendResponse({ error: "Unknown message type" });
+      return true;
+  }
+});
+
+// Start audio capture from tab
+async function startCapture(tabId, serverUrl) {
+  if (state.isCapturing) {
+    throw new Error("Already capturing");
+  }
+
+  try {
+    // Get the tab info
+    const tab = await chrome.tabs.get(tabId);
+
+    // Request tab capture
+    const streamId = await new Promise((resolve, reject) => {
+      chrome.tabCapture.capture(
+        {
+          audio: true,
+          video: false,
+        },
+        (stream) => {
+          if (chrome.runtime.lastError) {
+            reject(new Error(chrome.runtime.lastError.message));
+            return;
+          }
+          if (!stream) {
+            reject(new Error("Failed to capture tab audio"));
+            return;
+          }
+          resolve(stream);
+        }
+      );
+    });
+
+    state.mediaStream = streamId;
+    state.tabId = tabId;
+    state.tabUrl = tab.url;
+    state.serverUrl = serverUrl;
+
+    // Connect to WebSocket server
+    await connectWebSocket(serverUrl);
+
+    // Start audio processing
+    await startAudioProcessing(streamId);
+
+    state.isCapturing = true;
+
+    // Notify popup of state change
+    broadcastStateChange();
+
+    console.log("Audio capture started for tab:", tabId);
+  } catch (error) {
+    console.error("Failed to start capture:", error);
+    await cleanup();
+    throw error;
+  }
+}
+
+// Connect to WebSocket server
+async function connectWebSocket(serverUrl) {
+  return new Promise((resolve, reject) => {
+    const wsUrl = serverUrl.replace(/^http/, "ws") + "/api/audio";
+
+    console.log("Connecting to WebSocket:", wsUrl);
+
+    const ws = new WebSocket(wsUrl);
+
+    ws.onopen = () => {
+      console.log("WebSocket connected");
+      state.websocket = ws;
+      resolve();
+    };
+
+    ws.onerror = (error) => {
+      console.error("WebSocket error:", error);
+      reject(new Error("Failed to connect to server"));
+    };
+
+    ws.onclose = () => {
+      console.log("WebSocket closed");
+      if (state.isCapturing) {
+        // Connection lost while capturing, stop capture
+        stopCapture();
+      }
+    };
+
+    ws.onmessage = (event) => {
+      // Handle messages from server if needed
+      console.log("WebSocket message:", event.data);
+    };
+
+    // Timeout after 5 seconds
+    setTimeout(() => {
+      if (ws.readyState !== WebSocket.OPEN) {
+        ws.close();
+        reject(new Error("WebSocket connection timeout"));
+      }
+    }, 5000);
+  });
+}
+
+// Start processing audio from media stream
+async function startAudioProcessing(stream) {
+  // Create audio context
+  state.audioContext = new AudioContext({ sampleRate: 16000 });
+
+  // Create source from stream
+  const source = state.audioContext.createMediaStreamSource(stream);
+
+  // Create script processor for audio data
+  state.processor = state.audioContext.createScriptProcessor(4096, 1, 1);
+
+  state.processor.onaudioprocess = (event) => {
+    if (!state.websocket || state.websocket.readyState !== WebSocket.OPEN) {
+      return;
+    }
+
+    // Get audio data
+    const inputData = event.inputBuffer.getChannelData(0);
+
+    // Convert to 16-bit PCM
+    const pcm16 = new Int16Array(inputData.length);
+    for (let i = 0; i < inputData.length; i++) {
+      const s = Math.max(-1, Math.min(1, inputData[i]));
+      pcm16[i] = s < 0 ? s * 0x8000 : s * 0x7fff;
+    }
+
+    // Send to server
+    state.websocket.send(pcm16.buffer);
+  };
+
+  // Connect nodes
+  source.connect(state.processor);
+  state.processor.connect(state.audioContext.destination);
+}
+
+// Stop audio capture
+async function stopCapture() {
+  await cleanup();
+
+  state.isCapturing = false;
+  state.tabId = null;
+  state.tabUrl = null;
+
+  // Notify popup of state change
+  broadcastStateChange();
+
+  console.log("Audio capture stopped");
+}
+
+// Cleanup resources
+async function cleanup() {
+  // Stop processor
+  if (state.processor) {
+    state.processor.disconnect();
+    state.processor = null;
+  }
+
+  // Close audio context
+  if (state.audioContext) {
+    await state.audioContext.close();
+    state.audioContext = null;
+  }
+
+  // Stop media stream
+  if (state.mediaStream) {
+    state.mediaStream.getTracks().forEach((track) => track.stop());
+    state.mediaStream = null;
+  }
+
+  // Close WebSocket
+  if (state.websocket) {
+    state.websocket.close();
+    state.websocket = null;
+  }
+}
+
+// Broadcast state change to popup
+function broadcastStateChange() {
+  chrome.runtime.sendMessage({
+    type: "STATE_CHANGED",
+    state: {
+      isCapturing: state.isCapturing,
+      tabId: state.tabId,
+      tabUrl: state.tabUrl,
+    },
+  });
+}
+
+// Handle tab close
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (state.isCapturing && state.tabId === tabId) {
+    console.log("Captured tab was closed, stopping capture");
+    stopCapture();
+  }
+});
+
+// Handle extension unload
+self.addEventListener("unload", () => {
+  cleanup();
+});

--- a/extensions/chrome/content/content.js
+++ b/extensions/chrome/content/content.js
@@ -1,0 +1,101 @@
+// Content script for SyncVision Audio Capture
+// Injected into meeting pages (Google Meet, Zoom, Teams)
+
+// Detect meeting site
+const hostname = window.location.hostname;
+
+let meetingType = null;
+if (hostname.includes("meet.google.com")) {
+  meetingType = "google-meet";
+} else if (hostname.includes("zoom.us")) {
+  meetingType = "zoom";
+} else if (hostname.includes("teams.microsoft.com")) {
+  meetingType = "teams";
+}
+
+// Log detection
+console.log(`[SyncVision] Detected meeting site: ${meetingType || "none"}`);
+
+// Listen for messages from popup/background
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  switch (message.type) {
+    case "GET_MEETING_INFO":
+      sendResponse({
+        meetingType,
+        url: window.location.href,
+        title: document.title,
+      });
+      return true;
+
+    case "PING":
+      sendResponse({ pong: true });
+      return true;
+
+    default:
+      sendResponse({ error: "Unknown message type" });
+      return true;
+  }
+});
+
+// Notify background script that content script is loaded
+chrome.runtime.sendMessage({
+  type: "CONTENT_SCRIPT_LOADED",
+  meetingType,
+  url: window.location.href,
+});
+
+// Optional: Add visual indicator when capturing
+function showCaptureIndicator() {
+  const indicator = document.createElement("div");
+  indicator.id = "syncvision-indicator";
+  indicator.innerHTML = `
+    <style>
+      #syncvision-indicator {
+        position: fixed;
+        top: 10px;
+        right: 10px;
+        z-index: 999999;
+        background: rgba(239, 68, 68, 0.9);
+        color: white;
+        padding: 8px 12px;
+        border-radius: 6px;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+        font-size: 12px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      }
+      #syncvision-indicator .pulse {
+        width: 8px;
+        height: 8px;
+        background: white;
+        border-radius: 50%;
+        animation: syncvision-pulse 1.5s ease-in-out infinite;
+      }
+      @keyframes syncvision-pulse {
+        0%, 100% { opacity: 1; transform: scale(1); }
+        50% { opacity: 0.5; transform: scale(1.1); }
+      }
+    </style>
+    <span class="pulse"></span>
+    <span>SyncVision Recording</span>
+  `;
+  document.body.appendChild(indicator);
+}
+
+function hideCaptureIndicator() {
+  const indicator = document.getElementById("syncvision-indicator");
+  if (indicator) {
+    indicator.remove();
+  }
+}
+
+// Listen for capture state changes
+chrome.runtime.onMessage.addListener((message) => {
+  if (message.type === "CAPTURE_STARTED") {
+    showCaptureIndicator();
+  } else if (message.type === "CAPTURE_STOPPED") {
+    hideCaptureIndicator();
+  }
+});

--- a/extensions/chrome/icons/icon.svg
+++ b/extensions/chrome/icons/icon.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#8b5cf6;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="24" fill="url(#grad)"/>
+  <g fill="white">
+    <!-- Microphone icon -->
+    <rect x="52" y="24" width="24" height="44" rx="12"/>
+    <path d="M40 56v8a24 24 0 0 0 48 0v-8" fill="none" stroke="white" stroke-width="6" stroke-linecap="round"/>
+    <line x1="64" y1="88" x2="64" y2="100" stroke="white" stroke-width="6" stroke-linecap="round"/>
+    <line x1="50" y1="100" x2="78" y2="100" stroke="white" stroke-width="6" stroke-linecap="round"/>
+  </g>
+</svg>

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -1,0 +1,46 @@
+{
+  "manifest_version": 3,
+  "name": "SyncVision Audio Capture",
+  "description": "Capture audio from meeting tabs for real-time transcription in SyncVision",
+  "version": "1.0.0",
+  "permissions": [
+    "tabCapture",
+    "activeTab",
+    "storage"
+  ],
+  "host_permissions": [
+    "https://meet.google.com/*",
+    "https://*.zoom.us/*",
+    "https://teams.microsoft.com/*",
+    "http://localhost:*/*"
+  ],
+  "action": {
+    "default_popup": "popup/popup.html",
+    "default_icon": {
+      "16": "icons/icon16.png",
+      "32": "icons/icon32.png",
+      "48": "icons/icon48.png",
+      "128": "icons/icon128.png"
+    }
+  },
+  "background": {
+    "service_worker": "background/service-worker.js",
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://meet.google.com/*",
+        "https://*.zoom.us/*",
+        "https://teams.microsoft.com/*"
+      ],
+      "js": ["content/content.js"]
+    }
+  ],
+  "icons": {
+    "16": "icons/icon16.png",
+    "32": "icons/icon32.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  }
+}

--- a/extensions/chrome/popup/popup.html
+++ b/extensions/chrome/popup/popup.html
@@ -1,0 +1,268 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>SyncVision Audio Capture</title>
+  <style>
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      width: 320px;
+      padding: 16px;
+      background: #ffffff;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 16px;
+    }
+
+    .header h1 {
+      font-size: 16px;
+      font-weight: 600;
+      color: #1a1a1a;
+    }
+
+    .logo {
+      width: 24px;
+      height: 24px;
+      background: linear-gradient(135deg, #3b82f6, #8b5cf6);
+      border-radius: 6px;
+    }
+
+    .status-card {
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 12px;
+      margin-bottom: 16px;
+    }
+
+    .status-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 13px;
+    }
+
+    .status-label {
+      color: #64748b;
+    }
+
+    .status-value {
+      font-weight: 500;
+      color: #1a1a1a;
+    }
+
+    .status-value.recording {
+      color: #ef4444;
+    }
+
+    .status-value.idle {
+      color: #22c55e;
+    }
+
+    .tab-info {
+      font-size: 12px;
+      color: #64748b;
+      margin-top: 8px;
+      padding-top: 8px;
+      border-top: 1px solid #e2e8f0;
+      word-break: break-all;
+    }
+
+    .controls {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    button {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 10px 16px;
+      border: none;
+      border-radius: 6px;
+      font-size: 14px;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all 0.15s ease;
+    }
+
+    button:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    .btn-primary {
+      background: #3b82f6;
+      color: white;
+    }
+
+    .btn-primary:hover:not(:disabled) {
+      background: #2563eb;
+    }
+
+    .btn-danger {
+      background: #ef4444;
+      color: white;
+    }
+
+    .btn-danger:hover:not(:disabled) {
+      background: #dc2626;
+    }
+
+    .btn-secondary {
+      background: #f1f5f9;
+      color: #475569;
+      border: 1px solid #e2e8f0;
+    }
+
+    .btn-secondary:hover:not(:disabled) {
+      background: #e2e8f0;
+    }
+
+    .recording-indicator {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .pulse {
+      width: 8px;
+      height: 8px;
+      background: #ef4444;
+      border-radius: 50%;
+      animation: pulse 1.5s ease-in-out infinite;
+    }
+
+    @keyframes pulse {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50% { opacity: 0.5; transform: scale(1.1); }
+    }
+
+    .settings {
+      margin-top: 16px;
+      padding-top: 16px;
+      border-top: 1px solid #e2e8f0;
+    }
+
+    .settings-title {
+      font-size: 13px;
+      font-weight: 600;
+      color: #64748b;
+      margin-bottom: 8px;
+    }
+
+    .input-group {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+
+    .input-group label {
+      font-size: 12px;
+      color: #64748b;
+    }
+
+    .input-group input {
+      padding: 8px 10px;
+      border: 1px solid #e2e8f0;
+      border-radius: 6px;
+      font-size: 13px;
+    }
+
+    .input-group input:focus {
+      outline: none;
+      border-color: #3b82f6;
+      box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
+    }
+
+    .error {
+      background: #fef2f2;
+      border: 1px solid #fecaca;
+      color: #dc2626;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 12px;
+      margin-bottom: 12px;
+    }
+
+    .success {
+      background: #f0fdf4;
+      border: 1px solid #bbf7d0;
+      color: #16a34a;
+      padding: 8px 12px;
+      border-radius: 6px;
+      font-size: 12px;
+      margin-bottom: 12px;
+    }
+
+    .hidden {
+      display: none;
+    }
+  </style>
+</head>
+<body>
+  <div class="header">
+    <div class="logo"></div>
+    <h1>SyncVision Audio</h1>
+  </div>
+
+  <div id="error" class="error hidden"></div>
+  <div id="success" class="success hidden"></div>
+
+  <div class="status-card">
+    <div class="status-row">
+      <span class="status-label">Status</span>
+      <span id="status" class="status-value idle">Idle</span>
+    </div>
+    <div id="tabInfo" class="tab-info hidden"></div>
+  </div>
+
+  <div class="controls">
+    <button id="startBtn" class="btn-primary">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/>
+        <path d="M19 10v2a7 7 0 0 1-14 0v-2"/>
+        <line x1="12" x2="12" y1="19" y2="22"/>
+      </svg>
+      Start Capture
+    </button>
+    <button id="stopBtn" class="btn-danger hidden">
+      <div class="recording-indicator">
+        <span class="pulse"></span>
+        Stop Capture
+      </div>
+    </button>
+    <button id="openAppBtn" class="btn-secondary">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/>
+        <polyline points="15 3 21 3 21 9"/>
+        <line x1="10" x2="21" y1="14" y2="3"/>
+      </svg>
+      Open SyncVision
+    </button>
+  </div>
+
+  <div class="settings">
+    <div class="settings-title">Settings</div>
+    <div class="input-group">
+      <label for="serverUrl">Server URL</label>
+      <input type="text" id="serverUrl" placeholder="http://localhost:3000">
+    </div>
+  </div>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/extensions/chrome/popup/popup.js
+++ b/extensions/chrome/popup/popup.js
@@ -1,0 +1,155 @@
+// Popup script for SyncVision Audio Capture
+
+const DEFAULT_SERVER_URL = "http://localhost:3000";
+
+// DOM Elements
+const statusEl = document.getElementById("status");
+const tabInfoEl = document.getElementById("tabInfo");
+const startBtn = document.getElementById("startBtn");
+const stopBtn = document.getElementById("stopBtn");
+const openAppBtn = document.getElementById("openAppBtn");
+const serverUrlInput = document.getElementById("serverUrl");
+const errorEl = document.getElementById("error");
+const successEl = document.getElementById("success");
+
+// State
+let isCapturing = false;
+
+// Initialize
+document.addEventListener("DOMContentLoaded", async () => {
+  // Load saved settings
+  const { serverUrl } = await chrome.storage.local.get(["serverUrl"]);
+  serverUrlInput.value = serverUrl || DEFAULT_SERVER_URL;
+
+  // Get current capture state
+  const state = await getState();
+  updateUI(state);
+
+  // Listen for state changes
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.type === "STATE_CHANGED") {
+      updateUI(message.state);
+    }
+  });
+});
+
+// Event Listeners
+startBtn.addEventListener("click", startCapture);
+stopBtn.addEventListener("click", stopCapture);
+openAppBtn.addEventListener("click", openApp);
+serverUrlInput.addEventListener("change", saveSettings);
+
+// Functions
+async function getState() {
+  return new Promise((resolve) => {
+    chrome.runtime.sendMessage({ type: "GET_STATE" }, (response) => {
+      resolve(response || { isCapturing: false });
+    });
+  });
+}
+
+async function startCapture() {
+  hideMessages();
+
+  // Get current tab
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+
+  if (!tab) {
+    showError("No active tab found");
+    return;
+  }
+
+  // Check if tab is a supported meeting site
+  const supportedSites = ["meet.google.com", "zoom.us", "teams.microsoft.com"];
+  const url = new URL(tab.url);
+  const isSupported = supportedSites.some((site) => url.hostname.includes(site));
+
+  if (!isSupported) {
+    showError(
+      "Please navigate to a supported meeting site (Google Meet, Zoom, or Teams)"
+    );
+    return;
+  }
+
+  // Save server URL
+  await saveSettings();
+
+  // Send message to background to start capture
+  chrome.runtime.sendMessage(
+    {
+      type: "START_CAPTURE",
+      tabId: tab.id,
+      serverUrl: serverUrlInput.value || DEFAULT_SERVER_URL,
+    },
+    (response) => {
+      if (response?.error) {
+        showError(response.error);
+      } else if (response?.success) {
+        showSuccess("Audio capture started");
+        updateUI({ isCapturing: true, tabId: tab.id, tabUrl: tab.url });
+      }
+    }
+  );
+}
+
+async function stopCapture() {
+  hideMessages();
+
+  chrome.runtime.sendMessage({ type: "STOP_CAPTURE" }, (response) => {
+    if (response?.error) {
+      showError(response.error);
+    } else {
+      showSuccess("Audio capture stopped");
+      updateUI({ isCapturing: false });
+    }
+  });
+}
+
+async function openApp() {
+  const serverUrl = serverUrlInput.value || DEFAULT_SERVER_URL;
+  chrome.tabs.create({ url: `${serverUrl}/realtime` });
+}
+
+async function saveSettings() {
+  const serverUrl = serverUrlInput.value || DEFAULT_SERVER_URL;
+  await chrome.storage.local.set({ serverUrl });
+}
+
+function updateUI(state) {
+  isCapturing = state.isCapturing;
+
+  if (isCapturing) {
+    statusEl.textContent = "Recording";
+    statusEl.className = "status-value recording";
+    startBtn.classList.add("hidden");
+    stopBtn.classList.remove("hidden");
+
+    if (state.tabUrl) {
+      tabInfoEl.textContent = `Capturing: ${state.tabUrl}`;
+      tabInfoEl.classList.remove("hidden");
+    }
+  } else {
+    statusEl.textContent = "Idle";
+    statusEl.className = "status-value idle";
+    startBtn.classList.remove("hidden");
+    stopBtn.classList.add("hidden");
+    tabInfoEl.classList.add("hidden");
+  }
+}
+
+function showError(message) {
+  errorEl.textContent = message;
+  errorEl.classList.remove("hidden");
+  successEl.classList.add("hidden");
+}
+
+function showSuccess(message) {
+  successEl.textContent = message;
+  successEl.classList.remove("hidden");
+  errorEl.classList.add("hidden");
+}
+
+function hideMessages() {
+  errorEl.classList.add("hidden");
+  successEl.classList.add("hidden");
+}


### PR DESCRIPTION
## Summary
Add Chrome extension to capture audio from meeting tabs (Google Meet, Zoom, Teams) for real-time transcription.

## Features

### Tab Audio Capture
- Uses `chrome.tabCapture` API to capture tab audio
- Streams audio to web app via WebSocket (16kHz PCM)
- Supports Google Meet, Zoom Web, Microsoft Teams

### Extension UI
| Component | Description |
|-----------|-------------|
| Popup | Start/stop controls, server URL settings |
| Content Script | Meeting detection, visual recording indicator |
| Service Worker | Audio capture and streaming |

### Visual Feedback
- Recording indicator badge on meeting pages
- Status display in popup

## Files Added
```
extensions/chrome/
├── manifest.json           # Extension manifest (v3)
├── popup/
│   ├── popup.html         # Popup UI
│   └── popup.js           # Popup logic
├── background/
│   └── service-worker.js  # Audio capture
├── content/
│   └── content.js         # Meeting integration
├── icons/
│   └── icon.svg           # Extension icon
└── README.md              # Setup instructions
```

## Installation

1. Navigate to `chrome://extensions/`
2. Enable "Developer mode"
3. Click "Load unpacked"
4. Select `extensions/chrome` directory

See `extensions/chrome/README.md` for detailed instructions.

## Known Limitations
- Requires WebSocket API endpoint for full integration (future work)
- PNG icons need to be generated from SVG

## Test Plan
- [ ] Extension loads without errors
- [ ] Popup UI displays correctly
- [ ] Start capture works on Google Meet
- [ ] Recording indicator appears on page
- [ ] Stop capture works correctly

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)