### PR TITLE
feat(ws): add WebSocket server for extension audio streaming

### DIFF
--- a/extensions/chrome/README.md
+++ b/extensions/chrome/README.md
@@ -5,42 +5,46 @@ Chrome extension to capture audio from meeting tabs for real-time transcription 
 ## Features
 
 - Capture audio from Google Meet, Zoom Web, and Microsoft Teams
-- Stream audio to SyncVision web app for transcription
+- Stream audio to WebSocket server for transcription via Deepgram
 - Visual recording indicator on meeting pages
 
-## Installation
+## Quick Start
 
-### Development Mode
+### 1. Start the servers
+
+```bash
+# Terminal 1: Start Next.js web app
+npm run dev
+
+# Terminal 2: Start WebSocket server
+npm run dev:ws
+
+# Or run both together
+npm run dev:all
+```
+
+### 2. Install the extension
 
 1. Open Chrome and navigate to `chrome://extensions/`
 2. Enable "Developer mode" (toggle in top-right corner)
 3. Click "Load unpacked"
 4. Select this `extensions/chrome` directory
-5. The extension should appear in your toolbar
+5. The extension should appear in your toolbar (🎙️ icon)
 
-### Generate Icons
+### 3. Configure environment
 
-The extension requires PNG icons. Generate them from the SVG:
+Create `.env.local` in the project root:
 
-```bash
-# Using ImageMagick (install via Homebrew: brew install imagemagick)
-cd extensions/chrome/icons
-convert -background none icon.svg -resize 16x16 icon16.png
-convert -background none icon.svg -resize 32x32 icon32.png
-convert -background none icon.svg -resize 48x48 icon48.png
-convert -background none icon.svg -resize 128x128 icon128.png
+```
+DEEPGRAM_API_KEY=your_deepgram_api_key
 ```
 
-Or use any online SVG to PNG converter.
+### 4. Start capturing
 
-## Usage
-
-1. Start the SyncVision web app (`npm run dev`)
-2. Open a supported meeting site (Google Meet, Zoom, or Teams)
-3. Click the SyncVision extension icon
-4. Enter your server URL (default: `http://localhost:3000`)
-5. Click "Start Capture"
-6. The meeting audio will be transcribed in real-time
+1. Open a meeting (Google Meet, Zoom, or Teams)
+2. Click the SyncVision extension icon 🎙️
+3. Click "Start Capture"
+4. Open SyncVision web app to see transcription
 
 ## Supported Sites
 
@@ -50,37 +54,41 @@ Or use any online SVG to PNG converter.
 | Zoom Web | `*.zoom.us/*` |
 | Microsoft Teams | `teams.microsoft.com/*` |
 
-## Permissions
+## Server URLs
 
-- `tabCapture` - Required to capture tab audio
-- `activeTab` - Access current tab information
-- `storage` - Save user settings
+| Server | Default URL | Purpose |
+|--------|-------------|---------|
+| Web App | http://localhost:3000 | SyncVision UI |
+| WebSocket | http://localhost:3001 | Audio streaming |
 
-## Technical Details
-
-### Architecture
+## Architecture
 
 ```
-Extension                          Web App
-   │                                  │
-   ├── tabCapture API ───────────────>│
-   │   (capture audio)                │
-   │                                  │
-   ├── WebSocket ────────────────────>│ /api/audio
-   │   (stream PCM audio)             │
-   │                                  │
-   │                                  ├──> Deepgram
-   │                                  │    (transcription)
-   │                                  │
-   │                                  ├──> Gemini
-   │                                  │    (analysis)
+Chrome Extension                WebSocket Server              Deepgram
+      │                              │                           │
+      ├── tabCapture ───────────────>│                           │
+      │   (audio stream)             │                           │
+      │                              ├── WebSocket ─────────────>│
+      │                              │   (audio)                 │
+      │                              │<──────────────────────────┤
+      │<─────────────────────────────┤   (transcription)         │
+      │   (confirmation)             │                           │
+      │                              │                           │
+      │                              │───> Web App               │
+      │                              │     (broadcast)           │
 ```
 
-### Audio Format
+## Audio Format
 
 - Sample Rate: 16000 Hz
 - Channels: 1 (mono)
 - Format: 16-bit PCM (Int16Array)
+
+## Permissions
+
+- `tabCapture` - Capture tab audio
+- `activeTab` - Access current tab
+- `storage` - Save settings
 
 ## Development
 
@@ -88,18 +96,19 @@ Extension                          Web App
 
 | File | Description |
 |------|-------------|
-| `manifest.json` | Extension configuration |
+| `manifest.json` | Extension manifest (v3) |
 | `popup/popup.html` | Extension popup UI |
 | `popup/popup.js` | Popup logic |
-| `background/service-worker.js` | Audio capture and streaming |
+| `background/service-worker.js` | Audio capture & streaming |
 | `content/content.js` | Meeting site integration |
+| `icons/` | Extension icons (SVG with 🎙️) |
 
 ### Debugging
 
 1. Open `chrome://extensions/`
 2. Find SyncVision extension
-3. Click "service worker" to open DevTools for background script
-4. Click "Inspect views: popup" to debug popup
+3. Click "service worker" → DevTools for background
+4. Click "Inspect views: popup" → DevTools for popup
 
 ## Troubleshooting
 
@@ -109,11 +118,11 @@ Extension                          Web App
 - Try refreshing the page
 
 ### WebSocket connection failed
-- Verify the web app is running
-- Check the server URL is correct
-- Look for CORS errors in console
+- Verify WebSocket server is running (`npm run dev:ws`)
+- Check the server URL in extension settings
+- Default: `http://localhost:3001`
 
-### No audio data received
-- Check that the meeting audio is not muted
-- Verify the microphone/speaker is working
-- Try adjusting the volume
+### No transcription appears
+- Check DEEPGRAM_API_KEY is set in `.env.local`
+- Look for errors in WebSocket server console
+- Verify audio is not muted in the meeting

--- a/extensions/chrome/icons/icon.svg
+++ b/extensions/chrome/icons/icon.svg
@@ -1,16 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
-  <defs>
-    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
-      <stop offset="0%" style="stop-color:#3b82f6;stop-opacity:1" />
-      <stop offset="100%" style="stop-color:#8b5cf6;stop-opacity:1" />
-    </linearGradient>
-  </defs>
-  <rect width="128" height="128" rx="24" fill="url(#grad)"/>
-  <g fill="white">
-    <!-- Microphone icon -->
-    <rect x="52" y="24" width="24" height="44" rx="12"/>
-    <path d="M40 56v8a24 24 0 0 0 48 0v-8" fill="none" stroke="white" stroke-width="6" stroke-linecap="round"/>
-    <line x1="64" y1="88" x2="64" y2="100" stroke="white" stroke-width="6" stroke-linecap="round"/>
-    <line x1="50" y1="100" x2="78" y2="100" stroke="white" stroke-width="6" stroke-linecap="round"/>
-  </g>
+  <rect width="128" height="128" rx="24" fill="#1a1a1a"/>
+  <text x="64" y="88" font-size="80" text-anchor="middle" dominant-baseline="middle">🎙️</text>
 </svg>

--- a/extensions/chrome/icons/icon128.svg
+++ b/extensions/chrome/icons/icon128.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="24" fill="#1a1a1a"/>
+  <text x="64" y="89.6" font-size="80" text-anchor="middle">🎙️</text>
+</svg>

--- a/extensions/chrome/icons/icon16.svg
+++ b/extensions/chrome/icons/icon16.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16">
+  <rect width="16" height="16" rx="3" fill="#1a1a1a"/>
+  <text x="8" y="11.2" font-size="10" text-anchor="middle">🎙️</text>
+</svg>

--- a/extensions/chrome/icons/icon32.svg
+++ b/extensions/chrome/icons/icon32.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#1a1a1a"/>
+  <text x="16" y="22.4" font-size="20" text-anchor="middle">🎙️</text>
+</svg>

--- a/extensions/chrome/icons/icon48.svg
+++ b/extensions/chrome/icons/icon48.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 48 48">
+  <rect width="48" height="48" rx="9" fill="#1a1a1a"/>
+  <text x="24" y="33.599999999999994" font-size="30" text-anchor="middle">🎙️</text>
+</svg>

--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -17,10 +17,10 @@
   "action": {
     "default_popup": "popup/popup.html",
     "default_icon": {
-      "16": "icons/icon16.png",
-      "32": "icons/icon32.png",
-      "48": "icons/icon48.png",
-      "128": "icons/icon128.png"
+      "16": "icons/icon16.svg",
+      "32": "icons/icon32.svg",
+      "48": "icons/icon48.svg",
+      "128": "icons/icon128.svg"
     }
   },
   "background": {
@@ -38,9 +38,9 @@
     }
   ],
   "icons": {
-    "16": "icons/icon16.png",
-    "32": "icons/icon32.png",
-    "48": "icons/icon48.png",
-    "128": "icons/icon128.png"
+    "16": "icons/icon16.svg",
+    "32": "icons/icon32.svg",
+    "48": "icons/icon48.svg",
+    "128": "icons/icon128.svg"
   }
 }

--- a/extensions/chrome/popup/popup.html
+++ b/extensions/chrome/popup/popup.html
@@ -258,8 +258,8 @@
   <div class="settings">
     <div class="settings-title">Settings</div>
     <div class="input-group">
-      <label for="serverUrl">Server URL</label>
-      <input type="text" id="serverUrl" placeholder="http://localhost:3000">
+      <label for="serverUrl">WebSocket Server URL</label>
+      <input type="text" id="serverUrl" placeholder="http://localhost:3001">
     </div>
   </div>
 

--- a/extensions/chrome/popup/popup.js
+++ b/extensions/chrome/popup/popup.js
@@ -1,6 +1,7 @@
 // Popup script for SyncVision Audio Capture
 
-const DEFAULT_SERVER_URL = "http://localhost:3000";
+const DEFAULT_WS_SERVER_URL = "http://localhost:3001";
+const DEFAULT_APP_URL = "http://localhost:3000";
 
 // DOM Elements
 const statusEl = document.getElementById("status");
@@ -18,8 +19,8 @@ let isCapturing = false;
 // Initialize
 document.addEventListener("DOMContentLoaded", async () => {
   // Load saved settings
-  const { serverUrl } = await chrome.storage.local.get(["serverUrl"]);
-  serverUrlInput.value = serverUrl || DEFAULT_SERVER_URL;
+  const { wsServerUrl } = await chrome.storage.local.get(["wsServerUrl"]);
+  serverUrlInput.value = wsServerUrl || DEFAULT_WS_SERVER_URL;
 
   // Get current capture state
   const state = await getState();
@@ -79,7 +80,7 @@ async function startCapture() {
     {
       type: "START_CAPTURE",
       tabId: tab.id,
-      serverUrl: serverUrlInput.value || DEFAULT_SERVER_URL,
+      serverUrl: serverUrlInput.value || DEFAULT_WS_SERVER_URL,
     },
     (response) => {
       if (response?.error) {
@@ -106,13 +107,12 @@ async function stopCapture() {
 }
 
 async function openApp() {
-  const serverUrl = serverUrlInput.value || DEFAULT_SERVER_URL;
-  chrome.tabs.create({ url: `${serverUrl}/realtime` });
+  chrome.tabs.create({ url: `${DEFAULT_APP_URL}/realtime` });
 }
 
 async function saveSettings() {
-  const serverUrl = serverUrlInput.value || DEFAULT_SERVER_URL;
-  await chrome.storage.local.set({ serverUrl });
+  const wsServerUrl = serverUrlInput.value || DEFAULT_WS_SERVER_URL;
+  await chrome.storage.local.set({ wsServerUrl });
 }
 
 function updateUI(state) {

--- a/extensions/chrome/scripts/generate-icons.js
+++ b/extensions/chrome/scripts/generate-icons.js
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Generate PNG icons from emoji for Chrome extension
+ *
+ * Usage: node scripts/generate-icons.js
+ *
+ * This script creates simple PNG icons with the microphone emoji.
+ * For best results, manually create icons or use an online tool.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// Icon sizes required by Chrome extension
+const sizes = [16, 32, 48, 128];
+
+// Create a simple 1x1 PNG (placeholder)
+// In production, use proper image generation tools
+function createPlaceholderPng(size) {
+  // Minimal valid PNG (1x1 transparent pixel, will be scaled)
+  // This is a placeholder - for real icons, use ImageMagick or similar
+  const pngHeader = Buffer.from([
+    0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, // PNG signature
+    0x00, 0x00, 0x00, 0x0d, // IHDR length
+    0x49, 0x48, 0x44, 0x52, // IHDR
+    0x00, 0x00, 0x00, 0x01, // width
+    0x00, 0x00, 0x00, 0x01, // height
+    0x08, 0x06, // bit depth, color type (RGBA)
+    0x00, 0x00, 0x00, // compression, filter, interlace
+    0x1f, 0x15, 0xc4, 0x89, // CRC
+    0x00, 0x00, 0x00, 0x0a, // IDAT length
+    0x49, 0x44, 0x41, 0x54, // IDAT
+    0x78, 0x9c, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, // compressed data
+    0x0d, 0x0a, 0x2d, 0xb4, // CRC
+    0x00, 0x00, 0x00, 0x00, // IEND length
+    0x49, 0x45, 0x4e, 0x44, // IEND
+    0xae, 0x42, 0x60, 0x82, // CRC
+  ]);
+  return pngHeader;
+}
+
+// Alternative: Create SVG-based icons that Chrome can use
+function createSvgIcon(size) {
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
+  <rect width="${size}" height="${size}" rx="${Math.round(size * 0.1875)}" fill="#1a1a1a"/>
+  <text x="${size/2}" y="${size * 0.7}" font-size="${size * 0.625}" text-anchor="middle">🎙️</text>
+</svg>`;
+}
+
+const iconsDir = path.join(__dirname, '..', 'icons');
+
+// Ensure icons directory exists
+if (!fs.existsSync(iconsDir)) {
+  fs.mkdirSync(iconsDir, { recursive: true });
+}
+
+console.log('Generating Chrome extension icons...\n');
+console.log('Note: For best quality, use one of these methods:\n');
+console.log('1. ImageMagick (recommended):');
+console.log('   brew install imagemagick');
+sizes.forEach(size => {
+  console.log(`   convert -background none icons/icon.svg -resize ${size}x${size} icons/icon${size}.png`);
+});
+console.log('\n2. Online converter:');
+console.log('   https://cloudconvert.com/svg-to-png\n');
+
+// Create SVG files for each size (as backup)
+sizes.forEach(size => {
+  const svgContent = createSvgIcon(size);
+  const svgPath = path.join(iconsDir, `icon${size}.svg`);
+  fs.writeFileSync(svgPath, svgContent);
+  console.log(`Created: icons/icon${size}.svg`);
+});
+
+console.log('\nTo use SVG icons directly, update manifest.json:');
+console.log('Change "icon16.png" to "icon16.svg", etc.');
+console.log('\nOr generate PNGs using the commands above.');

--- a/features/sync-vision/hooks/useExtensionTranscript.ts
+++ b/features/sync-vision/hooks/useExtensionTranscript.ts
@@ -1,0 +1,174 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+
+interface TranscriptMessage {
+  type: "transcript";
+  transcript: string;
+  isFinal: boolean;
+  speaker?: string;
+}
+
+interface ConnectionMessage {
+  type: "connected" | "deepgram_connected" | "deepgram_disconnected";
+  message: string;
+  clientId?: string;
+}
+
+type WebSocketMessage = TranscriptMessage | ConnectionMessage;
+
+interface UseExtensionTranscriptOptions {
+  wsServerUrl?: string;
+  onTranscript?: (transcript: string, isFinal: boolean) => void;
+  autoConnect?: boolean;
+}
+
+interface UseExtensionTranscriptReturn {
+  isConnected: boolean;
+  isReceiving: boolean;
+  transcript: string;
+  interimTranscript: string;
+  error: string | null;
+  connect: () => void;
+  disconnect: () => void;
+  clearTranscript: () => void;
+}
+
+export function useExtensionTranscript({
+  wsServerUrl = "ws://localhost:3001",
+  onTranscript,
+  autoConnect = false,
+}: UseExtensionTranscriptOptions = {}): UseExtensionTranscriptReturn {
+  const [isConnected, setIsConnected] = useState(false);
+  const [isReceiving, setIsReceiving] = useState(false);
+  const [transcript, setTranscript] = useState("");
+  const [interimTranscript, setInterimTranscript] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const connect = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      return;
+    }
+
+    setError(null);
+
+    try {
+      const ws = new WebSocket(wsServerUrl);
+
+      ws.onopen = () => {
+        console.log("[ExtensionTranscript] Connected to WebSocket server");
+        setIsConnected(true);
+        setError(null);
+
+        // Subscribe to transcripts
+        ws.send(JSON.stringify({ type: "subscribe" }));
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const message: WebSocketMessage = JSON.parse(event.data);
+
+          switch (message.type) {
+            case "transcript":
+              if (message.isFinal) {
+                setTranscript((prev) =>
+                  prev ? `${prev} ${message.transcript}` : message.transcript
+                );
+                setInterimTranscript("");
+                setIsReceiving(true);
+                onTranscript?.(message.transcript, true);
+              } else {
+                setInterimTranscript(message.transcript);
+                onTranscript?.(message.transcript, false);
+              }
+              break;
+
+            case "deepgram_connected":
+              console.log("[ExtensionTranscript] Deepgram connected");
+              setIsReceiving(true);
+              break;
+
+            case "deepgram_disconnected":
+              console.log("[ExtensionTranscript] Deepgram disconnected");
+              setIsReceiving(false);
+              break;
+
+            case "connected":
+              console.log("[ExtensionTranscript] Server confirmed connection");
+              break;
+          }
+        } catch (e) {
+          console.error("[ExtensionTranscript] Failed to parse message:", e);
+        }
+      };
+
+      ws.onclose = () => {
+        console.log("[ExtensionTranscript] Disconnected from WebSocket server");
+        setIsConnected(false);
+        setIsReceiving(false);
+        wsRef.current = null;
+
+        // Auto-reconnect after 5 seconds if autoConnect is enabled
+        if (autoConnect) {
+          reconnectTimeoutRef.current = setTimeout(() => {
+            console.log("[ExtensionTranscript] Attempting to reconnect...");
+            connect();
+          }, 5000);
+        }
+      };
+
+      ws.onerror = (event) => {
+        console.error("[ExtensionTranscript] WebSocket error:", event);
+        setError("WebSocket connection error");
+      };
+
+      wsRef.current = ws;
+    } catch (e) {
+      console.error("[ExtensionTranscript] Failed to connect:", e);
+      setError("Failed to connect to WebSocket server");
+    }
+  }, [wsServerUrl, autoConnect, onTranscript]);
+
+  const disconnect = useCallback(() => {
+    if (reconnectTimeoutRef.current) {
+      clearTimeout(reconnectTimeoutRef.current);
+      reconnectTimeoutRef.current = null;
+    }
+
+    if (wsRef.current) {
+      wsRef.current.close();
+      wsRef.current = null;
+    }
+
+    setIsConnected(false);
+    setIsReceiving(false);
+  }, []);
+
+  const clearTranscript = useCallback(() => {
+    setTranscript("");
+    setInterimTranscript("");
+  }, []);
+
+  // Auto-connect on mount if enabled
+  useEffect(() => {
+    if (autoConnect) {
+      connect();
+    }
+
+    return () => {
+      disconnect();
+    };
+  }, [autoConnect, connect, disconnect]);
+
+  return {
+    isConnected,
+    isReceiving,
+    transcript,
+    interimTranscript,
+    error,
+    connect,
+    disconnect,
+    clearTranscript,
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "next": "^15.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^2.6.0"
+        "tailwind-merge": "^2.6.0",
+        "ws": "^8.19.0"
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
@@ -2155,6 +2156,27 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,28 +4,32 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
+    "dev:ws": "node server/ws-server.js",
+    "dev:all": "npm run dev & npm run dev:ws",
     "build": "next build",
     "start": "next start",
+    "start:ws": "node server/ws-server.js",
     "lint": "next lint",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@radix-ui/react-slot": "^1.1.1",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.468.0",
     "next": "^15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "lucide-react": "^0.468.0",
-    "clsx": "^2.1.1",
     "tailwind-merge": "^2.6.0",
-    "class-variance-authority": "^0.7.1",
-    "@radix-ui/react-slot": "^1.1.1"
+    "ws": "^8.19.0"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.0",
-    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
     "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0"
+    "tailwindcss": "^3.4.0",
+    "typescript": "^5.7.0"
   }
 }

--- a/server/ws-server.js
+++ b/server/ws-server.js
@@ -1,0 +1,280 @@
+/**
+ * WebSocket server for Chrome extension audio streaming
+ *
+ * Receives audio from Chrome extension and forwards to Deepgram for transcription.
+ * Broadcasts transcription results to connected web clients.
+ *
+ * Usage: node server/ws-server.js
+ */
+
+const WebSocket = require("ws");
+const http = require("http");
+
+// Configuration
+const PORT = process.env.WS_PORT || 3001;
+const DEEPGRAM_API_KEY = process.env.DEEPGRAM_API_KEY;
+
+// Create HTTP server
+const server = http.createServer((req, res) => {
+  // CORS headers for health check endpoint
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, OPTIONS");
+
+  if (req.url === "/health") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ status: "ok", clients: clients.size }));
+  } else {
+    res.writeHead(404);
+    res.end("Not found");
+  }
+});
+
+// Create WebSocket server
+const wss = new WebSocket.Server({ server });
+
+// Track connected clients
+const clients = new Map(); // clientId -> { ws, type, deepgramWs }
+
+// Generate client ID
+let clientIdCounter = 0;
+function generateClientId() {
+  return `client-${++clientIdCounter}-${Date.now()}`;
+}
+
+// Handle WebSocket connections
+wss.on("connection", (ws, req) => {
+  const clientId = generateClientId();
+  const clientType = req.url === "/api/audio" ? "extension" : "webapp";
+
+  console.log(`[${clientId}] Connected (${clientType})`);
+
+  clients.set(clientId, {
+    ws,
+    type: clientType,
+    deepgramWs: null,
+  });
+
+  // Send welcome message
+  ws.send(
+    JSON.stringify({
+      type: "connected",
+      clientId,
+      message: "Connected to SyncVision WebSocket server",
+    })
+  );
+
+  // Handle messages
+  ws.on("message", (data) => {
+    const client = clients.get(clientId);
+
+    if (client.type === "extension") {
+      // Audio data from Chrome extension
+      handleAudioData(clientId, data);
+    } else {
+      // Control messages from web app
+      try {
+        const message = JSON.parse(data.toString());
+        handleWebAppMessage(clientId, message);
+      } catch (e) {
+        console.error(`[${clientId}] Invalid message:`, e.message);
+      }
+    }
+  });
+
+  // Handle close
+  ws.on("close", () => {
+    console.log(`[${clientId}] Disconnected`);
+    const client = clients.get(clientId);
+
+    // Close Deepgram connection if exists
+    if (client?.deepgramWs) {
+      client.deepgramWs.close();
+    }
+
+    clients.delete(clientId);
+  });
+
+  // Handle errors
+  ws.on("error", (error) => {
+    console.error(`[${clientId}] Error:`, error.message);
+  });
+});
+
+// Handle audio data from Chrome extension
+function handleAudioData(clientId, audioData) {
+  const client = clients.get(clientId);
+  if (!client) return;
+
+  // Initialize Deepgram connection if not exists
+  if (!client.deepgramWs || client.deepgramWs.readyState !== WebSocket.OPEN) {
+    initDeepgramConnection(clientId);
+    return; // Wait for connection to establish
+  }
+
+  // Forward audio to Deepgram
+  if (client.deepgramWs.readyState === WebSocket.OPEN) {
+    client.deepgramWs.send(audioData);
+  }
+}
+
+// Initialize Deepgram WebSocket connection
+function initDeepgramConnection(clientId) {
+  const client = clients.get(clientId);
+  if (!client) return;
+
+  if (!DEEPGRAM_API_KEY) {
+    console.error("DEEPGRAM_API_KEY is not set");
+    client.ws.send(
+      JSON.stringify({
+        type: "error",
+        message: "Deepgram API key not configured",
+      })
+    );
+    return;
+  }
+
+  console.log(`[${clientId}] Connecting to Deepgram...`);
+
+  const deepgramUrl = new URL("wss://api.deepgram.com/v1/listen");
+  deepgramUrl.searchParams.set("model", "nova-2");
+  deepgramUrl.searchParams.set("language", "ja");
+  deepgramUrl.searchParams.set("punctuate", "true");
+  deepgramUrl.searchParams.set("interim_results", "true");
+  deepgramUrl.searchParams.set("encoding", "linear16");
+  deepgramUrl.searchParams.set("sample_rate", "16000");
+  deepgramUrl.searchParams.set("channels", "1");
+
+  const deepgramWs = new WebSocket(deepgramUrl.toString(), {
+    headers: {
+      Authorization: `Token ${DEEPGRAM_API_KEY}`,
+    },
+  });
+
+  deepgramWs.on("open", () => {
+    console.log(`[${clientId}] Deepgram connected`);
+    client.deepgramWs = deepgramWs;
+
+    // Notify client
+    client.ws.send(
+      JSON.stringify({
+        type: "deepgram_connected",
+        message: "Transcription started",
+      })
+    );
+  });
+
+  deepgramWs.on("message", (data) => {
+    try {
+      const result = JSON.parse(data.toString());
+
+      // Extract transcript
+      const transcript = result.channel?.alternatives?.[0]?.transcript;
+      const isFinal = result.is_final;
+
+      if (transcript) {
+        // Broadcast to all connected web app clients
+        broadcastToWebApps({
+          type: "transcript",
+          transcript,
+          isFinal,
+          speaker: result.channel?.alternatives?.[0]?.words?.[0]?.speaker,
+        });
+
+        // Also send back to extension for confirmation
+        client.ws.send(
+          JSON.stringify({
+            type: "transcript",
+            transcript,
+            isFinal,
+          })
+        );
+      }
+    } catch (e) {
+      console.error(`[${clientId}] Deepgram parse error:`, e.message);
+    }
+  });
+
+  deepgramWs.on("close", () => {
+    console.log(`[${clientId}] Deepgram disconnected`);
+    client.deepgramWs = null;
+
+    client.ws.send(
+      JSON.stringify({
+        type: "deepgram_disconnected",
+        message: "Transcription stopped",
+      })
+    );
+  });
+
+  deepgramWs.on("error", (error) => {
+    console.error(`[${clientId}] Deepgram error:`, error.message);
+    client.deepgramWs = null;
+  });
+}
+
+// Handle messages from web app
+function handleWebAppMessage(clientId, message) {
+  const client = clients.get(clientId);
+  if (!client) return;
+
+  switch (message.type) {
+    case "ping":
+      client.ws.send(JSON.stringify({ type: "pong" }));
+      break;
+
+    case "subscribe":
+      // Web app wants to receive transcripts
+      console.log(`[${clientId}] Subscribed to transcripts`);
+      break;
+
+    default:
+      console.log(`[${clientId}] Unknown message type:`, message.type);
+  }
+}
+
+// Broadcast message to all web app clients
+function broadcastToWebApps(message) {
+  const messageStr = JSON.stringify(message);
+
+  for (const [clientId, client] of clients) {
+    if (client.type === "webapp" && client.ws.readyState === WebSocket.OPEN) {
+      client.ws.send(messageStr);
+    }
+  }
+}
+
+// Start server
+server.listen(PORT, () => {
+  console.log(`
+╔════════════════════════════════════════════════════════╗
+║     SyncVision WebSocket Server                        ║
+╠════════════════════════════════════════════════════════╣
+║  Audio endpoint:  ws://localhost:${PORT}/api/audio         ║
+║  Web app endpoint: ws://localhost:${PORT}/                 ║
+║  Health check:    http://localhost:${PORT}/health          ║
+╠════════════════════════════════════════════════════════╣
+║  Environment:                                          ║
+║  - DEEPGRAM_API_KEY: ${DEEPGRAM_API_KEY ? "Set ✓" : "Not set ✗"}                       ║
+╚════════════════════════════════════════════════════════╝
+  `);
+});
+
+// Graceful shutdown
+process.on("SIGINT", () => {
+  console.log("\nShutting down...");
+
+  // Close all client connections
+  for (const [clientId, client] of clients) {
+    if (client.deepgramWs) {
+      client.deepgramWs.close();
+    }
+    client.ws.close();
+  }
+
+  wss.close(() => {
+    server.close(() => {
+      console.log("Server closed");
+      process.exit(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Add WebSocket server to enable Chrome extension → Deepgram audio streaming pipeline.

## Changes

### WebSocket Server
New `server/ws-server.js`:
- Receives PCM audio from Chrome extension
- Forwards to Deepgram for real-time transcription
- Broadcasts transcript results to connected web app clients
- Health check endpoint: `GET /health`

### Extension Updates
| Change | Before | After |
|--------|--------|-------|
| Icon | Custom SVG | Emoji 🎙️ |
| WS URL | localhost:3000 | localhost:3001 |
| Icons | PNG required | SVG supported |

### Web App
- `useExtensionTranscript` hook for receiving transcripts
- Auto-reconnect on disconnect

### NPM Scripts
```bash
npm run dev      # Next.js only (port 3000)
npm run dev:ws   # WebSocket server only (port 3001)
npm run dev:all  # Both servers
```

## Architecture
```
Extension → WS Server (3001) → Deepgram → WS Server → Web App (3000)
```

## Test Plan
- [ ] `npm run dev:ws` starts without errors
- [ ] Extension connects to WebSocket server
- [ ] Audio captured from meeting tab
- [ ] Transcription appears in server logs
- [ ] Web app receives broadcast transcripts

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)