### PR TITLE
chore(test): load env variables from .env.local in Playwright (#18)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/react-dom": "^19.0.0",
         "@types/ws": "^8.18.1",
         "autoprefixer": "^10.4.0",
+        "dotenv": "^17.2.3",
         "postcss": "^8.4.0",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.7.0"
@@ -1111,6 +1112,19 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.283",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/react-dom": "^19.0.0",
     "@types/ws": "^8.18.1",
     "autoprefixer": "^10.4.0",
+    "dotenv": "^17.2.3",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.7.0"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,9 @@
 import { defineConfig, devices } from "@playwright/test";
+import { config } from "dotenv";
+import path from "path";
+
+// Load environment variables from .env.local
+config({ path: path.resolve(__dirname, ".env.local") });
 
 export default defineConfig({
   testDir: "./e2e",


### PR DESCRIPTION
## Summary
- Configure Playwright to load environment variables from `.env.local`
- Enables API tests to access configured keys

## Changes
- Add `dotenv` dev dependency
- Update `playwright.config.ts` to load `.env.local` on startup

## Test Results (after fix)
```
Gemini API tests: 3 passed, 1 skipped
```

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)