### PR TITLE
feat(meeting-bridge): add meeting bot integration

### DIFF
--- a/features/sync-vision/components/LeftSidebar.tsx
+++ b/features/sync-vision/components/LeftSidebar.tsx
@@ -3,6 +3,7 @@
 import { MessageSquare } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { LogEntry } from "@/types";
+import { MeetingBotPanel } from "./MeetingBotPanel";
 
 interface LeftSidebarProps {
   logs: LogEntry[];
@@ -17,6 +18,11 @@ export function LeftSidebar({
 }: LeftSidebarProps) {
   return (
     <div className="w-72 bg-slate-50 border-r flex flex-col h-full">
+      {/* Meeting Bot Panel */}
+      <div className="p-3 border-b">
+        <MeetingBotPanel />
+      </div>
+
       <div className="p-4 border-b bg-white">
         <h2 className="font-semibold flex items-center gap-2">
           <MessageSquare className="h-4 w-4" />

--- a/features/sync-vision/components/MeetingBotPanel.tsx
+++ b/features/sync-vision/components/MeetingBotPanel.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Bot, Loader2, Square, Video, AlertCircle, CheckCircle2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  createBot,
+  getBotStatus,
+  leaveBot,
+  validateMeetingUrl,
+  getStatusLabel,
+  isBotActive,
+  type BotStatus,
+  type CreateBotResponse,
+} from "@/lib/api/meeting-bridge";
+
+interface MeetingBotPanelProps {
+  onTranscriptReceived?: (transcript: string) => void;
+}
+
+type PanelState = "idle" | "joining" | "active" | "error";
+
+export function MeetingBotPanel({ onTranscriptReceived }: MeetingBotPanelProps) {
+  const [meetingUrl, setMeetingUrl] = useState("");
+  const [urlError, setUrlError] = useState<string | null>(null);
+  const [panelState, setPanelState] = useState<PanelState>("idle");
+  const [botInfo, setBotInfo] = useState<CreateBotResponse | null>(null);
+  const [botStatus, setBotStatus] = useState<BotStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const pollingRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Cleanup polling on unmount
+  useEffect(() => {
+    return () => {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+      }
+    };
+  }, []);
+
+  // Poll for bot status when active
+  const startPolling = useCallback((botId: string) => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+    }
+
+    const poll = async () => {
+      try {
+        const status = await getBotStatus(botId);
+        setBotStatus(status.status as BotStatus);
+
+        // Stop polling if bot is done
+        if (status.status === "done" || status.status === "fatal") {
+          if (pollingRef.current) {
+            clearInterval(pollingRef.current);
+            pollingRef.current = null;
+          }
+          setPanelState(status.status === "fatal" ? "error" : "idle");
+        }
+      } catch (err) {
+        console.error("Polling error:", err);
+      }
+    };
+
+    // Poll every 5 seconds
+    pollingRef.current = setInterval(poll, 5000);
+    // Initial poll
+    poll();
+  }, []);
+
+  const handleUrlChange = (value: string) => {
+    setMeetingUrl(value);
+    setUrlError(null);
+
+    if (value.trim()) {
+      const validation = validateMeetingUrl(value);
+      if (!validation.valid) {
+        setUrlError(validation.error || "Invalid URL");
+      }
+    }
+  };
+
+  const handleJoinMeeting = async () => {
+    if (!meetingUrl.trim()) {
+      setUrlError("Please enter a meeting URL");
+      return;
+    }
+
+    const validation = validateMeetingUrl(meetingUrl);
+    if (!validation.valid) {
+      setUrlError(validation.error || "Invalid URL");
+      return;
+    }
+
+    setError(null);
+    setPanelState("joining");
+
+    try {
+      const result = await createBot({
+        meetingUrl,
+        botName: "SyncVision Bot",
+      });
+
+      setBotInfo(result);
+      setBotStatus(result.status as BotStatus);
+      setPanelState("active");
+      startPolling(result.botId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to join meeting");
+      setPanelState("error");
+    }
+  };
+
+  const handleLeaveMeeting = async () => {
+    if (!botInfo?.botId) return;
+
+    try {
+      await leaveBot(botInfo.botId);
+
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+
+      setBotInfo(null);
+      setBotStatus(null);
+      setPanelState("idle");
+      setMeetingUrl("");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to leave meeting");
+    }
+  };
+
+  const handleReset = () => {
+    if (pollingRef.current) {
+      clearInterval(pollingRef.current);
+      pollingRef.current = null;
+    }
+    setBotInfo(null);
+    setBotStatus(null);
+    setPanelState("idle");
+    setError(null);
+    setMeetingUrl("");
+    setUrlError(null);
+  };
+
+  return (
+    <div className="border rounded-lg bg-white shadow-sm">
+      <div className="p-3 border-b bg-gray-50 flex items-center gap-2">
+        <Bot className="h-4 w-4 text-primary" />
+        <span className="font-medium text-sm">Meeting Bot</span>
+        {botStatus && isBotActive(botStatus) && (
+          <span className="ml-auto flex items-center gap-1 text-xs text-green-600">
+            <span className="relative flex h-2 w-2">
+              <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+              <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500" />
+            </span>
+            Active
+          </span>
+        )}
+      </div>
+
+      <div className="p-3 space-y-3">
+        {/* Idle State - Show URL input */}
+        {panelState === "idle" && (
+          <>
+            <div className="space-y-1">
+              <Input
+                placeholder="Meeting URL (Google Meet, Zoom, Teams, Webex)"
+                value={meetingUrl}
+                onChange={(e) => handleUrlChange(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && !urlError) handleJoinMeeting();
+                }}
+                className={urlError ? "border-red-300" : ""}
+              />
+              {urlError && (
+                <p className="text-xs text-red-500 flex items-center gap-1">
+                  <AlertCircle className="h-3 w-3" />
+                  {urlError}
+                </p>
+              )}
+            </div>
+            <Button
+              onClick={handleJoinMeeting}
+              disabled={!meetingUrl.trim() || !!urlError}
+              className="w-full gap-2"
+              size="sm"
+            >
+              <Video className="h-4 w-4" />
+              Join Meeting
+            </Button>
+          </>
+        )}
+
+        {/* Joining State */}
+        {panelState === "joining" && (
+          <div className="flex items-center justify-center gap-2 py-4 text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            <span className="text-sm">Connecting bot to meeting...</span>
+          </div>
+        )}
+
+        {/* Active State - Show status and leave button */}
+        {panelState === "active" && botInfo && (
+          <>
+            <div className="space-y-2 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Status:</span>
+                <span className="font-medium flex items-center gap-1">
+                  {botStatus === "in_call_recording" && (
+                    <span className="relative flex h-2 w-2 mr-1">
+                      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75" />
+                      <span className="relative inline-flex rounded-full h-2 w-2 bg-red-500" />
+                    </span>
+                  )}
+                  {botStatus ? getStatusLabel(botStatus) : "Unknown"}
+                </span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Bot ID:</span>
+                <span className="font-mono text-xs bg-gray-100 px-2 py-0.5 rounded">
+                  {botInfo.botId.slice(0, 8)}...
+                </span>
+              </div>
+            </div>
+
+            <Button
+              onClick={handleLeaveMeeting}
+              variant="destructive"
+              className="w-full gap-2"
+              size="sm"
+            >
+              <Square className="h-4 w-4" />
+              Leave Meeting
+            </Button>
+          </>
+        )}
+
+        {/* Error State */}
+        {panelState === "error" && (
+          <>
+            <div className="flex items-center gap-2 text-red-600 text-sm">
+              <AlertCircle className="h-4 w-4" />
+              <span>{error || "An error occurred"}</span>
+            </div>
+            <Button onClick={handleReset} variant="outline" className="w-full" size="sm">
+              Try Again
+            </Button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/lib/api/meeting-bridge.ts
+++ b/lib/api/meeting-bridge.ts
@@ -1,0 +1,168 @@
+/**
+ * Meeting Bridge API Client
+ * Communicates with meeting-bridge Cloudflare Worker
+ */
+
+const MEETING_BRIDGE_URL =
+  process.env.NEXT_PUBLIC_MEETING_BRIDGE_URL ||
+  "https://meeting-bridge.nakabayashi-48f.workers.dev";
+
+export interface CreateBotRequest {
+  meetingUrl: string;
+  botName?: string;
+}
+
+export interface CreateBotResponse {
+  botId: string;
+  meetingUrl: string;
+  status: string;
+}
+
+export interface BotStatusResponse {
+  botId: string;
+  meetingUrl: string;
+  status: string;
+  videoUrl?: string;
+}
+
+export interface MeetingBridgeError {
+  error: string;
+  supportedPlatforms?: string[];
+}
+
+export type BotStatus =
+  | "created"
+  | "joining_call"
+  | "in_waiting_room"
+  | "in_call_not_recording"
+  | "in_call_recording"
+  | "call_ended"
+  | "done"
+  | "fatal";
+
+const SUPPORTED_PLATFORMS = [
+  "meet.google.com",
+  "zoom.us",
+  "teams.microsoft.com",
+  "webex.com",
+];
+
+/**
+ * Validate if the meeting URL is from a supported platform
+ */
+export function validateMeetingUrl(url: string): {
+  valid: boolean;
+  platform?: string;
+  error?: string;
+} {
+  try {
+    const urlObj = new URL(url);
+    const platform = SUPPORTED_PLATFORMS.find((p) =>
+      urlObj.hostname.includes(p)
+    );
+
+    if (!platform) {
+      return {
+        valid: false,
+        error: `Unsupported platform. Supported: ${SUPPORTED_PLATFORMS.join(", ")}`,
+      };
+    }
+
+    return { valid: true, platform };
+  } catch {
+    return { valid: false, error: "Invalid URL format" };
+  }
+}
+
+/**
+ * Create a bot to join a meeting
+ */
+export async function createBot(
+  request: CreateBotRequest
+): Promise<CreateBotResponse> {
+  const response = await fetch(`${MEETING_BRIDGE_URL}/api/bot/create`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as MeetingBridgeError;
+    throw new Error(error.error || "Failed to create bot");
+  }
+
+  return response.json();
+}
+
+/**
+ * Get bot status
+ */
+export async function getBotStatus(botId: string): Promise<BotStatusResponse> {
+  const response = await fetch(
+    `${MEETING_BRIDGE_URL}/api/bot/status?botId=${encodeURIComponent(botId)}`
+  );
+
+  if (!response.ok) {
+    const error = (await response.json()) as MeetingBridgeError;
+    throw new Error(error.error || "Failed to get bot status");
+  }
+
+  return response.json();
+}
+
+/**
+ * Remove bot from meeting
+ */
+export async function leaveBot(botId: string): Promise<void> {
+  const response = await fetch(`${MEETING_BRIDGE_URL}/api/bot/leave`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ botId }),
+  });
+
+  if (!response.ok) {
+    const error = (await response.json()) as MeetingBridgeError;
+    throw new Error(error.error || "Failed to remove bot");
+  }
+}
+
+/**
+ * Check if meeting-bridge service is available
+ */
+export async function checkHealth(): Promise<boolean> {
+  try {
+    const response = await fetch(`${MEETING_BRIDGE_URL}/health`);
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Get human-readable status label
+ */
+export function getStatusLabel(status: BotStatus): string {
+  const labels: Record<BotStatus, string> = {
+    created: "作成済み",
+    joining_call: "参加中...",
+    in_waiting_room: "待機室で待機中",
+    in_call_not_recording: "通話中（録音準備中）",
+    in_call_recording: "録音中",
+    call_ended: "通話終了",
+    done: "完了",
+    fatal: "エラー",
+  };
+  return labels[status] || status;
+}
+
+/**
+ * Check if bot is in an active state
+ */
+export function isBotActive(status: BotStatus): boolean {
+  return [
+    "joining_call",
+    "in_waiting_room",
+    "in_call_not_recording",
+    "in_call_recording",
+  ].includes(status);
+}


### PR DESCRIPTION
## Summary
- Add meeting-bridge API client for Cloudflare Worker communication
- Create MeetingBotPanel component for bot control UI
- Integrate MeetingBotPanel into LeftSidebar

## Features
- Enter meeting URL (Google Meet, Zoom, Teams, Webex)
- Create bot to join meeting via Recall.ai
- Real-time bot status polling
- Leave meeting control

## Screenshots
The MeetingBotPanel appears at the top of the left sidebar.

## Test plan
- [ ] Enter a valid Google Meet URL and verify bot joins
- [ ] Check bot status updates in the UI
- [ ] Click "Leave Meeting" and verify bot disconnects
- [ ] Try invalid URLs and verify error messages

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)